### PR TITLE
Clamp wire lamp distance

### DIFF
--- a/lua/tool_balance/tools/wire/lamp.lua
+++ b/lua/tool_balance/tools/wire/lamp.lua
@@ -1,0 +1,34 @@
+-- wire/lamp
+
+-- config
+local config = {
+    distance   = { min = 64, max = 2048 },
+}
+
+-- min and max values for gmod_wire_lamp
+local values = config
+
+local callAfter = cfcToolBalance.callAfter
+
+local function clampWireLampDistance( self, ... ) -- Wire lamps don't have a :SetDistance() function of any kind, making the clamping process abnormal
+    self.Dist = math.Clamp( self.Dist or 0, values.distance.min, values.distance.max )
+end
+
+local function wrapWireLamp()
+    local WIRE_LAMP =  scripted_ents.GetStored( "gmod_wire_lamp" ).t
+
+    WIRE_LAMP.UpdateLight = callAfter( clampWireLampDistance, WIRE_LAMP.UpdateLight )
+
+    print( "[CFC_Tool_Balance] wire/lamp loaded" )
+end
+
+local function waitingFor()
+    local ent = scripted_ents.GetStored( "gmod_wire_lamp" )
+    return ent and ent.t.UpdateLight ~= nil
+end
+
+local function onTimeout()
+    print( "[CFC_Tool_Balance] wire/lamp failed, waiter timed out" )
+end
+
+cfcToolBalance.waitFor( waitingFor, wrapWireLamp, onTimeout, "wire/lamp" )

--- a/lua/tool_balance/tools/wire/lamp.lua
+++ b/lua/tool_balance/tools/wire/lamp.lua
@@ -2,7 +2,7 @@
 
 -- config
 local config = {
-    distance   = { min = 64, max = 2048 },
+    distance = { min = 64, max = 2048 },
 }
 
 -- min and max values for gmod_wire_lamp


### PR DESCRIPTION
This prevents players from abusing out-of-bounds distance values on wire lamps to kill everyone's fps and spam their consoles with CUtl LinkedList errors. FOV and Brightness are already clamped internally by wiremod and aren't used for the exploit anyway, which is why they are excluded from the config for this clamp. The clamp applies any time a wire lamp is updated (i.e. spawned in, changed with wires, updated via toolgun, or turned on and off), so the clamp cannot be bypassed via wires, AdvDupe2, or other methods accessible to players.