### PR TITLE
Properly enforce regular lamp clamp

### DIFF
--- a/lua/tool_balance/tools/base/lamp.lua
+++ b/lua/tool_balance/tools/base/lamp.lua
@@ -11,6 +11,7 @@ local config = {
 local values = config
 
 local callAfter = cfcToolBalance.callAfter
+local IsValid = IsValid
 
 local function clampLamp( self, ... ) -- The setter functions for lamps get overridden by ENT.NetworkVar, so we cannot just wrap those functions and call it a day
     self:SetLightFOV( math.Clamp( self.fov or 0, values.fov.min, values.fov.max ) )
@@ -24,6 +25,7 @@ local function wrapLamp()
     LAMP.UpdateLight = callAfter( LAMP.UpdateLight, clampLamp )
 
     hook.Add( "OnEntityCreated", "CFCToolBalanceClampLamp", function( ent )
+        if not IsValid( ent ) then return end
         if ent:GetClass() ~= "gmod_lamp" then return end
 
         timer.Simple( 0.1, function()

--- a/lua/tool_balance/tools/base/lamp.lua
+++ b/lua/tool_balance/tools/base/lamp.lua
@@ -3,8 +3,8 @@
 -- config
 local config = {
     fov        = { min = 10, max = 170 },
-    distance   = { min = 64, max = 2048 },
-    brightness = { min = 0, max = 8 },
+    distance   = { min = 64, max = 1024 },
+    brightness = { min = 0, max = 3 },
 }
 
 -- min and max values for gmod_lamp

--- a/lua/tool_balance/tools/base/lamp.lua
+++ b/lua/tool_balance/tools/base/lamp.lua
@@ -28,7 +28,7 @@ local function wrapLamp()
         if not IsValid( ent ) then return end
         if ent:GetClass() ~= "gmod_lamp" then return end
 
-        timer.Simple( 0.1, function()
+        timer.Simple( 0, function()
             if not IsValid( ent ) then return end
 
             clampLamp( ent )

--- a/lua/tool_balance/tools/base/lamp.lua
+++ b/lua/tool_balance/tools/base/lamp.lua
@@ -22,7 +22,7 @@ end
 local function wrapLamp()
     local LAMP = scripted_ents.GetStored( "gmod_lamp" ).t
 
-    LAMP.UpdateLight = callAfter( LAMP.UpdateLight, clampLamp )
+    LAMP.UpdateLight = callAfter( clampLamp, LAMP.UpdateLight )
 
     hook.Add( "OnEntityCreated", "CFCToolBalanceClampLamp", function( ent )
         if not IsValid( ent ) then return end

--- a/lua/tool_balance/tools/wire/lamp.lua
+++ b/lua/tool_balance/tools/wire/lamp.lua
@@ -2,8 +2,8 @@
 
 -- config
 local config = {
-    fov = { min = 10, max = 170 },
-    distance = { min = 64, max = 1024 },
+    fov        = { min = 10, max = 170 },
+    distance   = { min = 64, max = 1024 },
     brightness = { min = 0, max = 3 },
 }
 

--- a/lua/tool_balance/tools/wire/lamp.lua
+++ b/lua/tool_balance/tools/wire/lamp.lua
@@ -2,7 +2,9 @@
 
 -- config
 local config = {
-    distance = { min = 64, max = 2048 },
+    fov = { min = 10, max = 170 },
+    distance = { min = 64, max = 1024 },
+    brightness = { min = 0, max = 3 },
 }
 
 -- min and max values for gmod_wire_lamp
@@ -10,14 +12,16 @@ local values = config
 
 local callAfter = cfcToolBalance.callAfter
 
-local function clampWireLampDistance( self, ... ) -- Wire lamps don't have a :SetDistance() function of any kind, making the clamping process abnormal
+local function clampWireLamp( self, ... ) -- Wire lamps don't have setter functions of any kind for these values
+    self.FOV = math.Clamp( self.FOV or 0, values.fov.min, values.fov.max )
     self.Dist = math.Clamp( self.Dist or 0, values.distance.min, values.distance.max )
+    self.Brightness = math.Clamp( self.Brightness or 0, values.brightness.min, values.brightness.max )
 end
 
 local function wrapWireLamp()
     local WIRE_LAMP =  scripted_ents.GetStored( "gmod_wire_lamp" ).t
 
-    WIRE_LAMP.UpdateLight = callAfter( clampWireLampDistance, WIRE_LAMP.UpdateLight )
+    WIRE_LAMP.UpdateLight = callAfter( clampWireLamp, WIRE_LAMP.UpdateLight )
 
     print( "[CFC_Tool_Balance] wire/lamp loaded" )
 end


### PR DESCRIPTION
This is pretty much redundant since the gmod_lamp entity already clamps itself when sending data over to the client, while gmod_wire_lamp does not, but this pr will cause the serverside values to be clamped as well.