### PR TITLE
Fix error causing wire lamps to spawn as world entities

### DIFF
--- a/lua/tool_balance/tools/wire/lamp.lua
+++ b/lua/tool_balance/tools/wire/lamp.lua
@@ -21,7 +21,7 @@ end
 local function wrapWireLamp()
     local WIRE_LAMP =  scripted_ents.GetStored( "gmod_wire_lamp" ).t
 
-    WIRE_LAMP.UpdateLight = callAfter( clampWireLampDistance, WIRE_LAMP.UpdateLight )
+    WIRE_LAMP.UpdateLight = callAfter( clampWireLamp, WIRE_LAMP.UpdateLight )
 
     print( "[CFC_Tool_Balance] wire/lamp loaded" )
 end


### PR DESCRIPTION
Fatal typo go brrrrrrrr