### PR TITLE
Clamp Scale Fire on phys_torque

### DIFF
--- a/lua/tool_balance/tools/base/motors.lua
+++ b/lua/tool_balance/tools/base/motors.lua
@@ -1,0 +1,18 @@
+local math_min = math.min
+local maxScale = 1000000
+
+local entMeta = FindMetaTable( "Entity" )
+entMeta._CFC_ToolBalance_Fire = entMeta._CFC_ToolBalance_Fire or entMeta.Fire
+
+function entMeta:Fire( input, param, delay, activator, caller )
+    if self:GetClass() == "phys_torque" then
+        if input == "Scale" then
+            local clamped = math_min( maxScale, param )
+            print( "[CFC_ToolBalance] phys_torque Scale clamped from", param, "to", clamped )
+
+            param = clamped
+        end
+    end
+
+    return self:_CFC_ToolBalance_Fire( input, param, delay, activator, caller )
+end

--- a/lua/tool_balance/tools/base/motors.lua
+++ b/lua/tool_balance/tools/base/motors.lua
@@ -7,10 +7,7 @@ entMeta._CFC_ToolBalance_Fire = entMeta._CFC_ToolBalance_Fire or entMeta.Fire
 function entMeta:Fire( input, param, delay, activator, caller )
     if self:GetClass() == "phys_torque" then
         if input == "Scale" then
-            local clamped = math_min( maxScale, param )
-            print( "[CFC_ToolBalance] phys_torque Scale clamped from", param, "to", clamped )
-
-            param = clamped
+            param = math_min( maxScale, param )
         end
     end
 


### PR DESCRIPTION
Fixes a stinky bug that happens if a `phys_torque` entity (motors) are `Fire`'d with too much `Scale`.

The same setup that would cause the bug before now behaves normally.

Before:
```
Stinky Bug (core dumped)
email debug.log to linux@valvesoftware.com
```

After:
```
[CFC_ToolBalance] phys_torque Scale clamped from        9.9999996802857e+38     to      1000000
```