### PR TITLE
Change values

### DIFF
--- a/lua/tool_balance/tools/wire/turret.lua
+++ b/lua/tool_balance/tools/wire/turret.lua
@@ -1,10 +1,10 @@
 -- config
 local config = {
     delay      = { min = 0.05, max = math.huge },
-    damage     = { min = 0,   max = 20 },
+    damage     = { min = 0,   max = 5 },
     force      = { min = 0,   max = 1 },
     numbullets = { min = 0,   max = 1 },
-    spread     = { min = 0,   max = 10 }
+    spread     = { min = 0.02,   max = 10 }
 }
 
 -- min and max values for gmod_wire_turret


### PR DESCRIPTION
Currently a single wire_turret is able to kill a player in 0.25 seconds, considering you can spawn 4 this pretty much is a oneshot.

To improve this this pr lowers the numbers to something more like guns use, the average m9k rifle does 400 damage per second, this pr makes it so turrets do roughly the same amount. It might seem like a large reduction but if you test it in game it is still is quite a quick kill.
I've also increased the minimum spread to avoid lazer accurate beams that people tend to abuse, 0.02 spread is super small but enough to prevent said beams.